### PR TITLE
Add apache license header on files 

### DIFF
--- a/src/CanalSharp.Client/ICanalConnector.cs
+++ b/src/CanalSharp.Client/ICanalConnector.cs
@@ -1,4 +1,20 @@
-﻿using CanalSharp.Protocol;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using CanalSharp.Protocol;
 
 namespace CanalSharp.Client
 {

--- a/src/CanalSharp.Client/ICanalNodeAccessStrategy.cs
+++ b/src/CanalSharp.Client/ICanalNodeAccessStrategy.cs
@@ -1,4 +1,20 @@
-﻿using System.Net;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
 
 namespace CanalSharp.Client
 {

--- a/src/CanalSharp.Client/Impl/CanalConnectors.cs
+++ b/src/CanalSharp.Client/Impl/CanalConnectors.cs
@@ -1,4 +1,20 @@
-﻿namespace CanalSharp.Client.Impl
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CanalSharp.Client.Impl
 {
     public class CanalConnectors
     {

--- a/src/CanalSharp.Client/Impl/Running/ClientRunningData.cs
+++ b/src/CanalSharp.Client/Impl/Running/ClientRunningData.cs
@@ -1,4 +1,20 @@
-﻿namespace CanalSharp.Client.Impl.Running
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CanalSharp.Client.Impl.Running
 {
     /// <summary>
     /// client running状态信息

--- a/src/CanalSharp.Client/Impl/Running/ClientRunningMonitor.cs
+++ b/src/CanalSharp.Client/Impl/Running/ClientRunningMonitor.cs
@@ -1,4 +1,20 @@
-﻿using CanalSharp.Common;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using CanalSharp.Common;
 
 namespace CanalSharp.Client.Impl.Running
 {

--- a/src/CanalSharp.Client/Impl/Running/IClientRunningListener.cs
+++ b/src/CanalSharp.Client/Impl/Running/IClientRunningListener.cs
@@ -1,4 +1,20 @@
-﻿using System.Net;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
 
 namespace CanalSharp.Client.Impl.Running
 {

--- a/src/CanalSharp.Client/Impl/SimpleCanalConnector.cs
+++ b/src/CanalSharp.Client/Impl/SimpleCanalConnector.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/CanalSharp.Client/Impl/SimpleNodeAccessStrategy.cs
+++ b/src/CanalSharp.Client/Impl/SimpleNodeAccessStrategy.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/src/CanalSharp.Common/AbstractCanalLifeCycle.cs
+++ b/src/CanalSharp.Common/AbstractCanalLifeCycle.cs
@@ -1,4 +1,20 @@
-﻿using CanalSharp.Common.Exception;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using CanalSharp.Common.Exception;
 
 namespace CanalSharp.Common
 {
@@ -7,7 +23,7 @@ namespace CanalSharp.Common
         /// <summary>
         /// 是否处于运行中
         /// </summary>
-        protected volatile bool Running; 
+        protected volatile bool Running;
 
         public bool IsStart()
         {

--- a/src/CanalSharp.Common/Alarm/ICanalAlarmHandler.cs
+++ b/src/CanalSharp.Common/Alarm/ICanalAlarmHandler.cs
@@ -1,4 +1,20 @@
-﻿namespace CanalSharp.Common.Alarm
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CanalSharp.Common.Alarm
 {
     /// <summary>
     ///  canal报警处理机制

--- a/src/CanalSharp.Common/Alarm/Impl/LogAlarmHandler.cs
+++ b/src/CanalSharp.Common/Alarm/Impl/LogAlarmHandler.cs
@@ -1,4 +1,20 @@
-﻿using CanalSharp.Common.Logging;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using CanalSharp.Common.Logging;
 using Microsoft.Extensions.Logging;
 
 namespace CanalSharp.Common.Alarm.Impl

--- a/src/CanalSharp.Common/Exception/CanalException.cs
+++ b/src/CanalSharp.Common/Exception/CanalException.cs
@@ -1,4 +1,20 @@
-﻿namespace CanalSharp.Common.Exception
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CanalSharp.Common.Exception
 {
     public class CanalException : System.Exception
     {

--- a/src/CanalSharp.Common/ICanalLifeCycle.cs
+++ b/src/CanalSharp.Common/ICanalLifeCycle.cs
@@ -1,4 +1,20 @@
-﻿namespace CanalSharp.Common
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CanalSharp.Common
 {
     public interface ICanalLifeCycle
     {

--- a/src/CanalSharp.Common/Logging/CanalSharpLogManager.cs
+++ b/src/CanalSharp.Common/Logging/CanalSharpLogManager.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using Microsoft.Extensions.Logging;
 
 namespace CanalSharp.Common.Logging

--- a/src/CanalSharp.Common/Utils/AddressUtils.cs
+++ b/src/CanalSharp.Common/Utils/AddressUtils.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.IO;
 using System.Linq;
 using System.Net;

--- a/src/CanalSharp.Common/Utils/BooleanMutex.cs
+++ b/src/CanalSharp.Common/Utils/BooleanMutex.cs
@@ -1,12 +1,28 @@
-﻿using System.Threading;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading;
 
 namespace CanalSharp.Common.Utils
 {
-   public class BooleanMutex
+    public class BooleanMutex
     {
         public void Set()
         {
-            Mutex mutex =new Mutex();
+            Mutex mutex = new Mutex();
             mutex.ReleaseMutex();
         }
     }

--- a/src/CanalSharp.Common/Zookeeper/Running/IServerRunningListener.cs
+++ b/src/CanalSharp.Common/Zookeeper/Running/IServerRunningListener.cs
@@ -1,4 +1,20 @@
-﻿namespace CanalSharp.Common.Zookeeper.Running
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CanalSharp.Common.Zookeeper.Running
 {
     public interface IServerRunningListener
     {

--- a/src/CanalSharp.Protocol/ClientIdentity.cs
+++ b/src/CanalSharp.Protocol/ClientIdentity.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace CanalSharp.Protocol
 {

--- a/src/CanalSharp.Protocol/Exception/CanalClientException.cs
+++ b/src/CanalSharp.Protocol/Exception/CanalClientException.cs
@@ -1,4 +1,20 @@
-﻿namespace CanalSharp.Protocol.Exception
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CanalSharp.Protocol.Exception
 {
     public class CanalClientException : System.Exception
     {

--- a/src/CanalSharp.Protocol/Message.cs
+++ b/src/CanalSharp.Protocol/Message.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using Com.Alibaba.Otter.Canal.Protocol;
 using Google.Protobuf;

--- a/src/CanalSharp.Protocol/Position/EntryPosition.cs
+++ b/src/CanalSharp.Protocol/Position/EntryPosition.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace CanalSharp.Protocol.Position
 {

--- a/src/CanalSharp.Protocol/Position/LogIdentity.cs
+++ b/src/CanalSharp.Protocol/Position/LogIdentity.cs
@@ -1,20 +1,36 @@
-﻿using System.Net;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net;
 
 namespace CanalSharp.Protocol.Position
 {
-    public class LogIdentity:Position
+    public class LogIdentity : Position
     {
         // 链接服务器的地址
-        public SocketAddress SourceAddress { get; }                         
+        public SocketAddress SourceAddress { get; }
+
         // 对应的slaveId
         public long? SlaveId { get; }
 
         public LogIdentity()
         {
-
         }
 
-        public LogIdentity(SocketAddress sourceAddress,long slaveId)
+        public LogIdentity(SocketAddress sourceAddress, long slaveId)
         {
             SourceAddress = sourceAddress;
             SlaveId = slaveId;
@@ -34,17 +50,19 @@ namespace CanalSharp.Protocol.Position
             if (this == obj) return true;
             if (obj == null) return false;
             if (this != obj) return false;
-            var other = (LogIdentity)obj;
+            var other = (LogIdentity) obj;
             if (SlaveId == null)
             {
                 if (other.SlaveId != null) return false;
             }
             else if (SlaveId != (other.SlaveId)) return false;
+
             if (SourceAddress == null)
             {
                 if (other.SourceAddress != null) return false;
             }
             else if (!SourceAddress.Equals(other.SourceAddress)) return false;
+
             return true;
         }
     }

--- a/src/CanalSharp.Protocol/Position/LogPosition.cs
+++ b/src/CanalSharp.Protocol/Position/LogPosition.cs
@@ -1,4 +1,20 @@
-﻿namespace CanalSharp.Protocol.Position
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CanalSharp.Protocol.Position
 {
     public class LogPosition : Position
     {

--- a/src/CanalSharp.Protocol/Position/MetaqPosition.cs
+++ b/src/CanalSharp.Protocol/Position/MetaqPosition.cs
@@ -1,4 +1,20 @@
-﻿namespace CanalSharp.Protocol.Position
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CanalSharp.Protocol.Position
 {
     public class MetaqPosition : Position
     {

--- a/src/CanalSharp.Protocol/Position/Position.cs
+++ b/src/CanalSharp.Protocol/Position/Position.cs
@@ -1,7 +1,23 @@
-﻿using System;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace CanalSharp.Protocol.Position
-{    
+{
     [Serializable]
     public abstract class Position
     {

--- a/src/CanalSharp.Protocol/Position/PositionRange.cs
+++ b/src/CanalSharp.Protocol/Position/PositionRange.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace CanalSharp.Protocol.Position
 {

--- a/src/CanalSharp.Protocol/Position/TimePosition.cs
+++ b/src/CanalSharp.Protocol/Position/TimePosition.cs
@@ -1,4 +1,20 @@
-﻿namespace CanalSharp.Protocol.Position
+﻿// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace CanalSharp.Protocol.Position
 {
     public class TimePosition : Position
     {


### PR DESCRIPTION
According to the Apache license that each source file should include the following license header.

```
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
```

This PR is used to fix this problem.

Related links:
https://www.apache.org/legal/src-headers.html